### PR TITLE
Go 311 central de notificacoes bug fix

### DIFF
--- a/packages/interfaces/src/interfaces/notifications/notifications.ts
+++ b/packages/interfaces/src/interfaces/notifications/notifications.ts
@@ -29,23 +29,13 @@ class NotificationsClass extends MongoCollectionClass<Notification, CreateNotifi
 	}
 
 	public async sendNotification(notification: CreateNotificationDto): Promise<void> {
-		const usersWithTopic = await users.findMany({ permissions: { $in: [notification.topic] } });
-
-		console.log('Users with topic ====>>>>>', usersWithTopic);
+		const usersWithTopic = await users.findMany({ 'permissions.action': notification.topic });
 
 		if (usersWithTopic.length === 0) return;
 
 		for (const user of usersWithTopic.filter(u => u._id !== notification.created_by)) {
 			const newNotification: CreateNotificationDto = { ...notification, user_id: user._id };
-			try {
-				const response = await notifications.insertOne(newNotification);
-				users.updateById(user._id, {
-					active_notifications: [...(user.active_notifications || []), response._id],
-				});
-			}
-			catch (err) {
-				console.error('Failed to update user notifications:', err);
-			}
+			await notifications.insertOne(newNotification);
 		}
 	}
 

--- a/packages/interfaces/src/interfaces/notifications/notifications.ts
+++ b/packages/interfaces/src/interfaces/notifications/notifications.ts
@@ -29,7 +29,10 @@ class NotificationsClass extends MongoCollectionClass<Notification, CreateNotifi
 	}
 
 	public async sendNotification(notification: CreateNotificationDto): Promise<void> {
-		const usersWithTopic = await users.findMany({ subscribed_topics: { $in: [notification.topic] } });
+		const usersWithTopic = await users.findMany({ permissions: { $in: [notification.topic] } });
+
+		console.log('Users with topic ====>>>>>', usersWithTopic);
+
 		if (usersWithTopic.length === 0) return;
 
 		for (const user of usersWithTopic.filter(u => u._id !== notification.created_by)) {

--- a/packages/interfaces/src/providers/auth/auth.ts
+++ b/packages/interfaces/src/providers/auth/auth.ts
@@ -38,7 +38,7 @@ class AuthProvider {
 		const userData = await this.getUser(sessionToken);
 		const rolesData = await roles.findMany({ _id: { $in: userData.role_ids } });
 
-		const allPermissions = [...rolesData.flatMap(role => role.permissions), ...userData.permissions, ...userData.subscribed_topics] as Permission<unknown>[];
+		const allPermissions = [...rolesData.flatMap(role => role.permissions), ...userData.permissions] as Permission<unknown>[];
 
 		const permissionsMap = new Map<string, Permission<unknown>>();
 

--- a/packages/types/src/auth/user.ts
+++ b/packages/types/src/auth/user.ts
@@ -21,7 +21,6 @@ export type UserPreferenceValue = z.infer<typeof UserPreferenceValueSchema>;
 /* * */
 
 export const UserSchema = DocumentSchema.extend({
-	active_notifications: z.array(z.string()).default([]),
 	avatar: z.string().nullish(),
 	bio: z.string().nullish(),
 	email: z.string().email(),
@@ -35,7 +34,6 @@ export const UserSchema = DocumentSchema.extend({
 	preferences: z.record(z.record(UserPreferenceValueSchema)).nullish(),
 	role_ids: z.array(z.string()).default([]),
 	session_ids: z.array(z.string()).default([]),
-	subscribed_topics: z.array(z.string()).default([]),
 	theme_id: z.string().nullish(),
 	verification_token_ids: z.array(z.string()).default([]),
 }).strict();


### PR DESCRIPTION
This pull request refactors how user permissions and notifications are managed, simplifying the user schema and notification logic. The main changes remove the concepts of `subscribed_topics` and `active_notifications` from user data, and update notification delivery to rely on user permissions instead of topic subscriptions.

**User Schema Simplification**
* Removed the `active_notifications` and `subscribed_topics` fields from the `UserSchema` in `user.ts`, streamlining user data and reducing redundancy. [[1]](diffhunk://#diff-de7b5296b1fff7343cc472e06af9bd453c269d441a3d5a29968908ce010467a0L24) [[2]](diffhunk://#diff-de7b5296b1fff7343cc472e06af9bd453c269d441a3d5a29968908ce010467a0L38)

**Notification Delivery Logic**
* Updated the `sendNotification` method in `notifications.ts` to select users based on the presence of a matching action in their `permissions` instead of `subscribed_topics`, and simplified notification insertion without updating user notification lists.

**Permission Management**
* Modified the permission aggregation in `auth.ts` to exclude `subscribed_topics` from the list of user permissions, ensuring permissions are sourced only from roles and explicit user permissions.