### PR TITLE
Go 311 Central de Notificações - Notificações por email

### DIFF
--- a/packages/emails/index.ts
+++ b/packages/emails/index.ts
@@ -2,17 +2,19 @@
 
 import { emailProvider } from '@/email.provider.js';
 import { FailedBackupEmailProps } from '@/emails/failed-backup.js';
+import { NotificationEmailProps } from '@/emails/notification-email.js';
 import { PlanApprovalRequestEmailProps } from '@/emails/plan-approval-request.js';
 import { ResetPasswordEmailProps } from '@/emails/reset-password.js';
 import { SucessfulGtfsValidationEmailProps } from '@/emails/sucessful-gtfs-validation.js';
 import { UnsuccessfulGtfsValidationEmailProps } from '@/emails/unsucessful-gtfs-validation.js';
 import { WelcomeEmailProps } from '@/emails/welcome.js';
-import { RenderFailedBackupEmail, RenderPlanApprovalRequestEmail, RenderResetPasswordEmail, RenderSucessfulGtfsValidationEmail, RenderUnsuccessfulGtfsValidationEmail, RenderWelcomeEmail } from '@/renderer.js';
+import { RenderEmailNotificationEmail, RenderFailedBackupEmail, RenderPlanApprovalRequestEmail, RenderResetPasswordEmail, RenderSucessfulGtfsValidationEmail, RenderUnsuccessfulGtfsValidationEmail, RenderWelcomeEmail } from '@/renderer.js';
 
 /* * */
 
 export type {
 	FailedBackupEmailProps,
+	NotificationEmailProps,
 	PlanApprovalRequestEmailProps,
 	ResetPasswordEmailProps,
 	SucessfulGtfsValidationEmailProps,
@@ -73,6 +75,15 @@ export async function sendPlanApprovalRequestEmail(props: SendEmailProps<PlanApp
 	await emailProvider.send({
 		html: emailHtml,
 		subject: 'Pedido de aprovação de plano',
+		to: props.to,
+	});
+};
+
+export async function sendNotificationEmail(props: SendEmailProps<NotificationEmailProps>) {
+	const emailHtml = await RenderEmailNotificationEmail(props.props);
+	await emailProvider.send({
+		html: emailHtml,
+		subject: 'Nova Notificação',
 		to: props.to,
 	});
 };

--- a/packages/emails/src/emails/notification-email.tsx
+++ b/packages/emails/src/emails/notification-email.tsx
@@ -2,22 +2,19 @@
 
 import { EmailWrapper, InfoBox, styles } from '@/components/index.js';
 import { Button, Hr, Section, Text } from '@react-email/components';
-import { getAppConfig } from '@tmlmobilidade/lib';
-import { type UnixTimestamp } from '@tmlmobilidade/types';
-import { Dates } from '@tmlmobilidade/utils';
 
 /* * */
 
 export interface NotificationEmailProps {
-	action: string
-	creation_date: UnixTimestamp
-	description: string
+	body: string
+	href: string
+	priority: string
+	scope: string
 	title: string
+	topic: string
 }
 
-export function NotificationEmail({ action, creation_date, description, title }: NotificationEmailProps) {
-	const url = getAppConfig('plans', 'frontend_url') + '/validations/';
-
+export function NotificationEmail({ body, href, priority, scope, title, topic }: NotificationEmailProps) {
 	return (
 		<EmailWrapper preview="Pedido de aprovação de plano">
 			<Section>
@@ -42,15 +39,15 @@ export function NotificationEmail({ action, creation_date, description, title }:
 						{title}
 						<br />
 						<strong>Descrição</strong>
-						{description}
+						{body}
 						<br />
-						<strong>Data de Criação:</strong>
+						<strong>Prioridade:</strong>
 						{' '}
-						{Dates.fromUnixTimestamp(creation_date).setZone('Europe/Lisbon', 'offset_only').toLocaleString(Dates.FORMATS.DATETIME_SHORT, 'pt-PT')}
+						{priority}
 					</Text>
 				</InfoBox>
 
-				<Button href={url} style={styles.button}>
+				<Button href={href} style={styles.button}>
 					Ver Notificação
 				</Button>
 

--- a/packages/emails/src/emails/notification-email.tsx
+++ b/packages/emails/src/emails/notification-email.tsx
@@ -14,36 +14,52 @@ export interface NotificationEmailProps {
 	topic: string
 }
 
+/* * */
+
 export function NotificationEmail({ body, href, priority, scope, title, topic }: NotificationEmailProps) {
+	//
+
+	//
+	// A. Setup variables
+	const priorityMap: Record<string, string> = {
+		high: 'Alta',
+		low: 'Baixa',
+		normal: 'Média',
+	};
+
+	//
+	// B. Render components
+
 	return (
-		<EmailWrapper preview="Pedido de aprovação de plano">
+		<EmailWrapper preview="Nova notificação">
 			<Section>
 				<Text style={styles.text}>
 					👋 Olá,
 				</Text>
 
 				<Text style={styles.text}>
-					Tens uma nova notificação
+					Tens uma nova notificação.
 				</Text>
 
 				<Hr style={{ margin: '24px 0' }} />
 
 				<InfoBox variant="info">
 					<Text style={{ ...styles.text, margin: '0 0 12px 0' }}>
-						<strong>📋 Detalhes da Notificação</strong>
+						<strong>🔔 Detalhes da Notificação</strong>
 					</Text>
 
 					<Text style={{ ...styles.text, margin: '8px 0' }}>
-						<strong>Titulo</strong>
+						<strong>Titulo:</strong>
 						{' '}
 						{title}
 						<br />
-						<strong>Descrição</strong>
+						<strong>Descrição:</strong>
+						{' '}
 						{body}
 						<br />
 						<strong>Prioridade:</strong>
 						{' '}
-						{priority}
+						{priorityMap[priority]}
 					</Text>
 				</InfoBox>
 
@@ -54,6 +70,8 @@ export function NotificationEmail({ body, href, priority, scope, title, topic }:
 			</Section>
 		</EmailWrapper>
 	);
+
+	//
 };
 
 export default NotificationEmail;

--- a/packages/emails/src/emails/notification-email.tsx
+++ b/packages/emails/src/emails/notification-email.tsx
@@ -1,0 +1,62 @@
+/* * */
+
+import { EmailWrapper, InfoBox, styles } from '@/components/index.js';
+import { Button, Hr, Section, Text } from '@react-email/components';
+import { getAppConfig } from '@tmlmobilidade/lib';
+import { type UnixTimestamp } from '@tmlmobilidade/types';
+import { Dates } from '@tmlmobilidade/utils';
+
+/* * */
+
+export interface NotificationEmailProps {
+	action: string
+	creation_date: UnixTimestamp
+	description: string
+	title: string
+}
+
+export function NotificationEmail({ action, creation_date, description, title }: NotificationEmailProps) {
+	const url = getAppConfig('plans', 'frontend_url') + '/validations/';
+
+	return (
+		<EmailWrapper preview="Pedido de aprovação de plano">
+			<Section>
+				<Text style={styles.text}>
+					👋 Olá,
+				</Text>
+
+				<Text style={styles.text}>
+					Tens uma nova notificação
+				</Text>
+
+				<Hr style={{ margin: '24px 0' }} />
+
+				<InfoBox variant="info">
+					<Text style={{ ...styles.text, margin: '0 0 12px 0' }}>
+						<strong>📋 Detalhes da Notificação</strong>
+					</Text>
+
+					<Text style={{ ...styles.text, margin: '8px 0' }}>
+						<strong>Titulo</strong>
+						{' '}
+						{title}
+						<br />
+						<strong>Descrição</strong>
+						{description}
+						<br />
+						<strong>Data de Criação:</strong>
+						{' '}
+						{Dates.fromUnixTimestamp(creation_date).setZone('Europe/Lisbon', 'offset_only').toLocaleString(Dates.FORMATS.DATETIME_SHORT, 'pt-PT')}
+					</Text>
+				</InfoBox>
+
+				<Button href={url} style={styles.button}>
+					Ver Notificação
+				</Button>
+
+			</Section>
+		</EmailWrapper>
+	);
+};
+
+export default NotificationEmail;

--- a/packages/emails/src/renderer.tsx
+++ b/packages/emails/src/renderer.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 /* * */
 
 import { FailedBackupEmail, FailedBackupEmailProps } from './emails/failed-backup.js';
+import { NotificationEmail, NotificationEmailProps } from './emails/notification-email.js';
 import { PlanApprovalRequestEmail, PlanApprovalRequestEmailProps } from './emails/plan-approval-request.js';
 import { ResetPasswordEmail, ResetPasswordEmailProps } from './emails/reset-password.js';
 import { SucessfulGtfsValidationEmail, SucessfulGtfsValidationEmailProps } from './emails/sucessful-gtfs-validation.js';
@@ -36,4 +37,8 @@ export const RenderUnsuccessfulGtfsValidationEmail = async (props: UnsuccessfulG
 
 export const RenderPlanApprovalRequestEmail = async (props: PlanApprovalRequestEmailProps) => {
 	return await render(<PlanApprovalRequestEmail {...props} />);
+};
+
+export const RenderEmailNotificationEmail = async (props: NotificationEmailProps) => {
+	return await render(<NotificationEmail {...props} />);
 };

--- a/packages/interfaces/src/interfaces/notifications/notifications.ts
+++ b/packages/interfaces/src/interfaces/notifications/notifications.ts
@@ -1,7 +1,9 @@
 /* * */
 
 import { MongoCollectionClass } from '@/mongo-collection.js';
-import { CreateNotificationDto, Notification, NotificationSchema, UpdateNotificationDto, UpdateNotificationSchema } from '@tmlmobilidade/types';
+import { sendNotificationEmail } from '@tmlmobilidade/emails';
+import { getAppConfig } from '@tmlmobilidade/lib';
+import { CreateNotificationDto, Notification, NotificationPermission, NotificationSchema, UpdateNotificationDto, UpdateNotificationSchema, User } from '@tmlmobilidade/types';
 import { AsyncSingletonProxy } from '@tmlmobilidade/utils';
 import { IndexDescription } from 'mongodb';
 import { z } from 'zod';
@@ -28,13 +30,42 @@ class NotificationsClass extends MongoCollectionClass<Notification, CreateNotifi
 		return NotificationsClass._instance;
 	}
 
-	public async sendNotification(notification: CreateNotificationDto): Promise<void> {
-		const usersWithTopic = await users.findMany({ 'permissions.action': notification.topic });
+	public async sendNotification(scope: string, topic: string, user: User, id: string, title: string, description: string): Promise<void> {
+		const usersWithTopic: User[] = await users.findMany({ 'permissions.action': topic });
 
 		if (usersWithTopic.length === 0) return;
 
+		const notification: CreateNotificationDto = {
+			created_by: user?._id,
+			is_read: false,
+			payload: {
+				body: description,
+				href: `${getAppConfig(`${topic}`, 'frontend_url')}/${topic}/${id}`,
+				icon: topic,
+				title: title,
+			},
+			priority: 'normal',
+			scope: scope,
+			topic: topic,
+			updated_by: user?._id,
+		};
+
 		for (const user of usersWithTopic.filter(u => u._id !== notification.created_by)) {
+			const sendMail = user?.permissions.find(p => p.scope === 'notifications' && p.action === 'created_alert')?.resource as NotificationPermission ?? false;
 			const newNotification: CreateNotificationDto = { ...notification, user_id: user._id };
+			if (sendMail) {
+				await sendNotificationEmail({
+					props: {
+						body: notification.payload.body,
+						href: notification.payload.href || '',
+						priority: notification.priority,
+						scope: notification.scope,
+						title: notification.payload.title,
+						topic: notification.topic,
+					}, to: user.email,
+				});
+			}
+
 			await notifications.insertOne(newNotification);
 		}
 	}

--- a/packages/types/src/auth/permission.ts
+++ b/packages/types/src/auth/permission.ts
@@ -8,12 +8,10 @@ export const PermissionSchema = z.object({
 	action: z.string(),
 	resource: z.record(z.any()).nullish(),
 	scope: z.string(),
-	send_email: z.boolean().default(false).nullish(),
 });
 
 export interface Permission<T> {
 	action: string
 	resource?: Partial<Record<keyof T, T[keyof T]>>
 	scope: string
-	send_email?: boolean
 }

--- a/packages/types/src/auth/permission.ts
+++ b/packages/types/src/auth/permission.ts
@@ -8,10 +8,12 @@ export const PermissionSchema = z.object({
 	action: z.string(),
 	resource: z.record(z.any()).nullish(),
 	scope: z.string(),
+	send_email: z.boolean().default(false).nullish(),
 });
 
 export interface Permission<T> {
 	action: string
 	resource?: Partial<Record<keyof T, T[keyof T]>>
 	scope: string
+	send_email?: boolean
 }

--- a/packages/types/src/auth/user.ts
+++ b/packages/types/src/auth/user.ts
@@ -3,7 +3,6 @@
 import { DocumentSchema } from '@/_common/document.js';
 import { unixTimeStampSchema } from '@/_common/unix-timestamp.js';
 import { type Permission, PermissionSchema } from '@/auth/permission.js';
-import { NotificationSchema } from '@/notification.js';
 import { z } from 'zod';
 
 /* * */

--- a/packages/types/src/notification.ts
+++ b/packages/types/src/notification.ts
@@ -9,7 +9,6 @@ export type Notification = z.infer<typeof NotificationSchema>;
 
 export const NotificationSchema = DocumentSchema.extend({
 	is_read: z.boolean(),
-	needs_email: z.boolean().default(false),
 	payload: z.object({
 		body: z.string().min(1),
 		href: z.string().url().optional(),
@@ -31,3 +30,9 @@ export type CreateNotificationDto = z.infer<typeof CreateNotificationSchema>;
 export type UpdateNotificationDto = z.infer<typeof UpdateNotificationSchema>;
 
 /* * */
+
+export const NotificationPermissionSchema = z.object({
+	send_mail: z.boolean().default(false).nullish(),
+});
+
+export type NotificationPermission = z.infer<typeof NotificationPermissionSchema>;


### PR DESCRIPTION
This pull request introduces a new notification email feature to the email system, allowing the application to send notification emails with customizable content and priority. It includes the implementation of the notification email template, integration into the email sending workflow, and updates to types to support the new feature.

**Notification Email Feature:**

* Added a new email template component `NotificationEmail` in `notification-email.tsx`, supporting props for body, title, priority, scope, topic, and a link (`href`). The template displays notification details and includes a button to view the notification.
* Created the `NotificationEmailProps` type and exported it in `index.ts` to define the structure of notification email properties.
* Implemented the `sendNotificationEmail` function in `index.ts` to render and send notification emails using the new template and props.
* Added the `RenderEmailNotificationEmail` renderer to `renderer.tsx` for generating the HTML of notification emails. [[1]](diffhunk://#diff-e26c386158ddf42b8b02d4da18ec687570c8f33d2129310bc53fa60a8c031197R41-R44) [[2]](diffhunk://#diff-e26c386158ddf42b8b02d4da18ec687570c8f33d2129310bc53fa60a8c031197R9)

**Permission System Update:**

* Extended the `Permission` type and schema in `permission.ts` to include an optional `send_email` boolean, allowing permissions to specify whether email sending is allowed.